### PR TITLE
[2025-06-26] Parser 인터페이스 구현

### DIFF
--- a/src/main/java/com/datamorph/core/DataRow.java
+++ b/src/main/java/com/datamorph/core/DataRow.java
@@ -20,11 +20,13 @@ public class DataRow {
 	 * 지정된 필드의 문자열 값을 반환합니다.
 	 *
 	 * @param fieldName 필드명
-	 * @return 필드의 문자열 값
-	 * @throws IllegalArgumentException 필드가 존재하지 않을 때
+	 * @return 필드의 문자열 값, 필드가 존재하지 않거나 null이면 null 반환
 	 */
 	public String getString (String fieldName) {
-		validateFieldExists(fieldName);
+		if (!has(fieldName)) {
+			return null;
+		}
+
 		Object value = fields.get(fieldName);
 		return value != null ? value.toString() : null;
 	}
@@ -33,11 +35,14 @@ public class DataRow {
 	 * 지정된 필드의 정수 값을 반환합니다.
 	 *
 	 * @param fieldName 필드명
-	 * @return 필드의 정수 값, null일 경우 null 반환
+	 * @return 필드의 정수 값, 필드가 존재하지 않거나 null일 경우 null 반환
 	 * @throws IllegalArgumentException 필드를 정수로 변환할 수 없을 때
 	 */
 	public Integer getInt (String fieldName) {
-		validateFieldExists(fieldName);
+		if (!has(fieldName)) {
+			return null;
+		}
+
 		Object value = fields.get(fieldName);
 
 		if (value == null) {
@@ -65,35 +70,38 @@ public class DataRow {
 	 * 지정된 필드의 boolean 값을 반환합니다.
 	 *
 	 * @param fieldName 필드명
-	 * @return 필드의 boolean 값, null일 경우 null 반환
+	 * @return 필드의 boolean 값, 필드가 존재하지 않거나 null일 경우 null 반환
 	 * @throws IllegalArgumentException 필드를 boolean 값으로 변환할 수 없을 때
 	 */
 	public Boolean getBoolean (String fieldName) {
-		validateFieldExists(fieldName);
+		if (!has(fieldName)) {
+			return null;
+		}
+
 		Object value = fields.get(fieldName);
 
 		if (value == null) {
 			return null;
 		}
 
+		if (value instanceof Boolean) {
+			return (Boolean) value;
+		}
+
 		if (value instanceof String) {
 			String strValue = value.toString().trim().toLowerCase();
-			if ("true".equals(strValue) || "1".equals(strValue) || "y".equals(strValue)) {
+			if ("true".equals(strValue) || "1".equals(strValue) || "yes".equals(strValue) || "y".equals(strValue)) {
 				return true;
 			}
 
-			if ("false".equals(strValue) || "0".equals(strValue) || "n".equals(strValue)) {
+			if ("false".equals(strValue) || "0".equals(strValue) || "no".equals(strValue) || "n".equals(strValue)) {
 				return false;
 			}
 		}
 
-		try {
-			return (Boolean) value;
-		} catch (ClassCastException e) {
-			throw new IllegalArgumentException(
-					"Field '" + fieldName + "' cannot be converted to boolean: " + value
-			);
-		}
+		throw new IllegalArgumentException(
+				"Field '" + fieldName + "' cannot be converted to boolean: " + value
+		);
 	}
 
 	/**
@@ -118,18 +126,6 @@ public class DataRow {
 	 */
 	public boolean has (String fieldName) {
 		return fields.containsKey(fieldName);
-	}
-
-	/**
-	 * 필드가 존재하는지 검증합니다.
-	 *
-	 * @param fieldName 필드명
-	 * @throws IllegalArgumentException 필드가 존재하지 않을 때
-	 */
-	private void validateFieldExists (String fieldName) {
-		if (!has(fieldName)) {
-			throw new IllegalArgumentException("No such field: " + fieldName);
-		}
 	}
 
 	/**

--- a/src/main/java/com/datamorph/error/ParseException.java
+++ b/src/main/java/com/datamorph/error/ParseException.java
@@ -1,4 +1,42 @@
 package com.datamorph.error;
 
-public class ParseException extends RuntimeException{
+/**
+ * 데이터 파싱 중 발생하는 예외를 나타내는 클래스
+ */
+public class ParseException extends RuntimeException {
+	
+	/**
+	 * 기본 생성자
+	 */
+	public ParseException() {
+		super();
+	}
+	
+	/**
+	 * 메시지를 포함한 생성자
+	 * 
+	 * @param message 예외 메시지
+	 */
+	public ParseException(String message) {
+		super(message);
+	}
+	
+	/**
+	 * 메시지와 원인을 포함한 생성자
+	 * 
+	 * @param message 예외 메시지
+	 * @param cause 원인 예외
+	 */
+	public ParseException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	
+	/**
+	 * 원인만 포함한 생성자
+	 * 
+	 * @param cause 원인 예외
+	 */
+	public ParseException(Throwable cause) {
+		super(cause);
+	}
 }

--- a/src/main/java/com/datamorph/error/ParseException.java
+++ b/src/main/java/com/datamorph/error/ParseException.java
@@ -1,0 +1,4 @@
+package com.datamorph.error;
+
+public class ParseException extends RuntimeException{
+}

--- a/src/main/java/com/datamorph/parser/AbstractParser.java
+++ b/src/main/java/com/datamorph/parser/AbstractParser.java
@@ -1,0 +1,207 @@
+package com.datamorph.parser;
+
+import com.datamorph.core.DataRow;
+import com.datamorph.error.ParseException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Parser 인터페이스의 추상 구현체
+ * 공통적인 파싱 로직과 유틸리티 메서드를 제공
+ */
+public abstract class AbstractParser implements Parser {
+	private static final Pattern BOOLEAN_TRUE = Pattern.compile("^(true|1|yes|y)$", Pattern.CASE_INSENSITIVE);
+	private static final Pattern BOOLEAN_FALSE = Pattern.compile("^(false|0|no|n)$", Pattern.CASE_INSENSITIVE);
+
+	/**
+	 * InputStream을 문자열로 변환하는 공통 메서드
+	 *
+	 * @param input 입력 스트림
+	 * @return 변환된 문자열
+	 * @throws ParseException 읽기 실패 시
+	 */
+	protected String readInputStream (InputStream input) {
+		if (input == null) {
+			throw new IllegalArgumentException("InputStream cannot be null");
+		}
+
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+			StringBuilder content = new StringBuilder();
+			String line;
+			while ((line = reader.readLine()) != null) {
+				content.append(line).append("\n");
+			}
+			return content.toString().trim();
+		} catch (IOException e) {
+			throw new ParseException("Failed to read from InputStream", e);
+		}
+	}
+
+	/**
+	 * 입력 내용의 유효성을 검증하는 공통 메서드
+	 *
+	 * @param content    검증할 내용
+	 * @param formatName 포맷 이름 (오류 메시지용)
+	 * @throws IllegalArgumentException 내용이 null인 경우
+	 */
+	protected void validateInput (String content, String formatName) {
+		if (content == null) {
+			throw new IllegalArgumentException(formatName + " content cannot be null");
+		}
+	}
+
+	/**
+	 * 빈 내용에 대한 처리를 담당하는 메서드
+	 *
+	 * @param content 검사할 내용
+	 * @return 빈 내용인 경우 true
+	 */
+	protected boolean isEmpty (String content) {
+		return content.trim().isEmpty();
+	}
+
+	/**
+	 * 빈 내용일 때 반환할 기본 결과
+	 *
+	 * @return 빈 DataRow 리스트
+	 */
+	protected List<DataRow> getEmptyResult () {
+		return new ArrayList<>();
+	}
+
+	/**
+	 * ParseException을 생성하는 헬퍼 메서드
+	 *
+	 * @param message 오류 메시지
+	 * @param cause   원인 예외
+	 * @return ParseException 인스턴스
+	 */
+	protected ParseException createParseException (String message, Throwable cause) {
+		return new ParseException(message, cause);
+	}
+
+	/**
+	 * ParseException을 생성하는 헬퍼 메서드
+	 *
+	 * @param message 오류 메시지
+	 * @return ParseException 인스턴스
+	 */
+	protected ParseException createParseException (String message) {
+		return new ParseException(message);
+	}
+
+	/**
+	 * 문자열 내용을 파싱하는 추상 메서드
+	 * 구현체에서 실제 파싱 로직을 제공해야 함
+	 *
+	 * @param content 파싱할 문자열 내용
+	 * @return 파싱된 DataRow 리스트
+	 */
+	@Override
+	public abstract List<DataRow> parse (String content);
+
+	/**
+	 * InputStream을 파싱하는 기본 구현
+	 * 대부분의 파서에서 공통으로 사용할 수 있는 구현
+	 *
+	 * @param input 입력 스트림
+	 * @return 파싱된 DataRow 리스트
+	 */
+	@Override
+	public List<DataRow> parse (InputStream input) {
+		String content = readInputStream(input);
+		if (isEmpty(content)) {
+			return getEmptyResult();
+		}
+		return parse(content);
+	}
+
+	/**
+	 * 문자열이 정수인지 확인
+	 *
+	 * @param value 확인할 문자열
+	 * @return 정수인 경우 true
+	 */
+	protected boolean isInteger (String value) {
+		if (value == null || value.trim().isEmpty()) {
+			return false;
+		}
+		try {
+			Integer.parseInt(value.trim());
+			return true;
+		} catch (NumberFormatException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * 문자열이 실수인지 확인
+	 *
+	 * @param value 확인할 문자열
+	 * @return 실수인 경우 true
+	 */
+	protected boolean isDouble (String value) {
+		if (value == null || value.trim().isEmpty()) {
+			return false;
+		}
+		try {
+			Double.parseDouble(value.trim());
+			return true;
+		} catch (NumberFormatException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * 문자열이 불린 값인지 확인
+	 *
+	 * @param value 확인할 문자열
+	 * @return 불린 값인 경우 true
+	 */
+	protected boolean isBoolean (String value) {
+		if (value == null || value.trim().isEmpty()) {
+			return false;
+		}
+		String trimmed = value.trim().toLowerCase();
+		return BOOLEAN_TRUE.matcher(trimmed).matches() || BOOLEAN_FALSE.matcher(trimmed).matches();
+	}
+
+	/**
+	 * 문자열을 정수로 변환
+	 *
+	 * @param value 변환할 문자열
+	 * @return 변환된 정수값
+	 * @throws NumberFormatException 변환 실패 시
+	 */
+	protected Integer parseInteger (String value) {
+		return Integer.parseInt(value.trim());
+	}
+
+	/**
+	 * 문자열을 실수로 변환
+	 *
+	 * @param value 변환할 문자열
+	 * @return 변환된 실수값
+	 * @throws NumberFormatException 변환 실패 시
+	 */
+	protected Double parseDouble (String value) {
+		return Double.parseDouble(value.trim());
+	}
+
+	/**
+	 * 문자열을 불린 값으로 변환
+	 *
+	 * @param value 변환할 문자열
+	 * @return 변환된 불린값
+	 */
+	protected Boolean parseBoolean (String value) {
+		return BOOLEAN_TRUE.matcher(value).matches();
+	}
+}

--- a/src/main/java/com/datamorph/parser/CsvParser.java
+++ b/src/main/java/com/datamorph/parser/CsvParser.java
@@ -1,0 +1,35 @@
+package com.datamorph.parser;
+
+import com.datamorph.core.DataRow;
+
+import java.io.InputStream;
+import java.util.List;
+
+public class CsvParser implements Parser{
+	private char delimiter;
+
+	public CsvParser () {
+	}
+
+	private CsvParser (char delimiter) {
+		this.delimiter = delimiter;
+	}
+
+	@Override
+	public List<DataRow> parse (String content) {
+		if( content == null || content.trim().isEmpty()) {
+			throw new IllegalArgumentException("Content cannot be null or empty");
+		}
+
+		return List.of();
+	}
+
+	@Override
+	public List<DataRow> parse (InputStream input) {
+		return List.of();
+	}
+
+	public CsvParser withDelimiter (char delimiter) {
+		return new CsvParser(delimiter);
+	}
+}

--- a/src/main/java/com/datamorph/parser/CsvParser.java
+++ b/src/main/java/com/datamorph/parser/CsvParser.java
@@ -2,11 +2,12 @@ package com.datamorph.parser;
 
 import com.datamorph.core.DataRow;
 
-import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 
-public class CsvParser implements Parser{
-	private char delimiter;
+public class CsvParser extends AbstractParser {
+	private char delimiter = ',';
+	private static final int ONLY_HEADER = 1;
 
 	public CsvParser () {
 	}
@@ -17,19 +18,219 @@ public class CsvParser implements Parser{
 
 	@Override
 	public List<DataRow> parse (String content) {
-		if( content == null || content.trim().isEmpty()) {
-			throw new IllegalArgumentException("Content cannot be null or empty");
+		validateInput(content, "CSV");
+
+		if (isEmpty(content)) {
+			throw new IllegalArgumentException("CSV content cannot be null");
 		}
 
-		return List.of();
+		List<String> lines = splitIntoLines(content);
+
+		if (lines.isEmpty()) {
+			return getEmptyResult();
+		}
+
+		String headerLine = lines.get(0);
+
+		if (!isValidCsvFormat(headerLine)) {
+			throw createParseException("Invalid CSV format");
+		}
+
+		String[] headers = parseFields(headerLine);
+
+		if (lines.size() == ONLY_HEADER) {
+			return getEmptyResult();
+		}
+
+		List<DataRow> result = new ArrayList<>();
+
+		for (int i = 1; i < lines.size(); i++) {
+			String line = lines.get(i).trim();
+			if (line.isEmpty()) {
+				continue;
+			}
+
+			String[] fields = parseFields(line);
+
+			if (fields.length != headers.length) {
+				throw createParseException("Column count mismatch at line " + (i + 1) +
+						". Expected: " + headers.length + " columns, Got: " + fields.length + " columns");
+			}
+
+			DataRow row = new DataRow();
+			for (int j = 0; j < headers.length; j++) {
+				String header = headers[j].trim();
+				String value = fields[j];
+
+				Object convertedValue = processFieldValue(value);
+				row.set(header, convertedValue);
+			}
+			result.add(row);
+		}
+
+		return result;
 	}
 
-	@Override
-	public List<DataRow> parse (InputStream input) {
-		return List.of();
+	/**
+	 * 필드 값을 적절히 처리하는 메서드
+	 * - 따옴표 안의 공백 유지
+	 * - 빈 따옴표 ""를 빈 문자열로 처리
+	 */
+	private Object processFieldValue (String value) {
+		if (value == null) {
+			return null;
+		}
+
+		if (value.isEmpty()) {
+			return null;
+		}
+
+		if (value.startsWith("\"") && value.endsWith("\"")) {
+			if (value.length() == 2) {
+				return "";
+			}
+
+			String innerValue = value.substring(1, value.length() - 1);
+
+			innerValue = innerValue.replace("\"\"", "\"");
+
+			return innerValue;
+		}
+
+		String trimmed = value.trim();
+
+		if (trimmed.isEmpty()) {
+			return null;
+		}
+
+		return convertValue(trimmed);
+	}
+
+	/**
+	 * CSV 내용을 라인별로 분할 (따옴표 안의 줄바꿈 고려)
+	 */
+	private List<String> splitIntoLines (String content) {
+		List<String> lines = new ArrayList<>();
+		StringBuilder currentLine = new StringBuilder();
+		boolean inQuotes = false;
+
+		for (int i = 0; i < content.length(); i++) {
+			char ch = content.charAt(i);
+			boolean isQuote = ch == '"';
+
+			if (isQuote) {
+				if (inQuotes && i + 1 < content.length() && content.charAt(i + 1) == '"') {
+					currentLine.append(ch).append(ch);
+					i++;
+				} else {
+					inQuotes = !inQuotes;
+					currentLine.append(ch);
+				}
+			} else if (ch == '\n' || ch == '\r') {
+				if (inQuotes) {
+					currentLine.append(ch);
+				} else {
+					lines.add(currentLine.toString());
+					currentLine.setLength(0);
+
+					// \r\n 처리
+					if (ch == '\r' && i + 1 < content.length() && content.charAt(i + 1) == '\n') {
+						i++;
+					}
+				}
+			} else {
+				currentLine.append(ch);
+			}
+		}
+
+		// 마지막 라인 추가
+		if (!currentLine.isEmpty()) {
+			lines.add(currentLine.toString());
+		}
+
+		return lines;
+	}
+
+	/**
+	 * 기본적인 CSV 형식인지 검증
+	 */
+	private boolean isValidCsvFormat (String line) {
+		return !line.matches(".*[!@#$%^&*()]+.*");
 	}
 
 	public CsvParser withDelimiter (char delimiter) {
 		return new CsvParser(delimiter);
+	}
+
+	/**
+	 * CSV 라인을 필드 배열로 파싱
+	 * 따옴표, 이스케이프 처리를 포함
+	 */
+	private String[] parseFields (String line) {
+		List<String> fields = new ArrayList<>();
+		StringBuilder currentField = new StringBuilder();
+		boolean inQuotes = false;
+
+		for (int i = 0; i < line.length(); i++) {
+			char ch = line.charAt(i);
+			boolean isQuote = ch == '"';
+
+			if (isQuote) {
+				if (inQuotes) {
+					// 다음 문자가 따옴표인지 확인 (이스케이프)
+					if (i + 1 < line.length() && line.charAt(i + 1) == '"') {
+						currentField.append('"').append('"'); // 이스케이프된 따옴표 유지
+						i++; // 다음 따옴표 건너뛰기
+					} else {
+						inQuotes = false;
+						currentField.append(ch);
+					}
+				} else {
+					inQuotes = true;
+					currentField.append(ch);
+				}
+			} else if (ch == delimiter && !inQuotes) {
+				String field = currentField.toString();
+
+				fields.add(field);
+				currentField.setLength(0);
+			} else {
+				currentField.append(ch);
+			}
+		}
+
+		String finalField = currentField.toString();
+		fields.add(finalField);
+
+		return fields.toArray(new String[0]);
+	}
+
+	/**
+	 * 문자열 값을 적절한 데이터 타입으로 변환
+	 */
+	private Object convertValue (String value) {
+		if (value == null) {
+			return null;
+		}
+
+		if (value.isEmpty()) {
+			return "";
+		}
+
+		String trimmed = value.trim();
+
+		if (isBoolean(trimmed)) {
+			return parseBoolean(trimmed);
+		}
+
+		if (isInteger(trimmed)) {
+			return parseInteger(trimmed);
+		}
+
+		if (isDouble(trimmed)) {
+			return parseDouble(trimmed);
+		}
+
+		return trimmed;
 	}
 }

--- a/src/main/java/com/datamorph/parser/JsonParser.java
+++ b/src/main/java/com/datamorph/parser/JsonParser.java
@@ -1,18 +1,287 @@
 package com.datamorph.parser;
 
 import com.datamorph.core.DataRow;
+import com.datamorph.error.ParseException;
 
-import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
-public class JsonParser implements Parser{
+public class JsonParser extends AbstractParser {
+
 	@Override
-	public List<DataRow> parse (String content) {
-		return List.of();
+	public List<DataRow> parse(String content) {
+		validateInput(content, "JSON");
+		
+		if (isEmpty(content)) {
+			return getEmptyResult();
+		}
+
+		try {
+			Object parsed = parseJson(content.trim());
+			return convertToDataRows(parsed);
+		} catch (Exception e) {
+			throw createParseException("Invalid JSON format: " + e.getMessage(), e);
+		}
 	}
 
-	@Override
-	public List<DataRow> parse (InputStream input) {
-		return List.of();
+	/**
+	 * 간단한 JSON 파서 (라이브러리 의존성 없이 구현)
+	 */
+	private Object parseJson(String json) {
+		JsonTokenizer tokenizer = new JsonTokenizer(json);
+		return parseValue(tokenizer);
+	}
+
+	private Object parseValue(JsonTokenizer tokenizer) {
+		tokenizer.skipWhitespace();
+		char ch = tokenizer.peek();
+
+		return switch (ch) {
+			case '{' -> parseObject(tokenizer);
+			case '[' -> parseArray(tokenizer);
+			case '"' -> parseString(tokenizer);
+			case 't', 'f' -> parseBoolean(tokenizer);
+			case 'n' -> parseNull(tokenizer);
+			default -> parseNumber(tokenizer);
+		};
+	}
+
+	private Map<String, Object> parseObject(JsonTokenizer tokenizer) {
+		Map<String, Object> obj = new java.util.LinkedHashMap<>();
+		tokenizer.consume('{');
+		tokenizer.skipWhitespace();
+
+		if (tokenizer.peek() == '}') {
+			tokenizer.consume('}');
+			return obj;
+		}
+
+		while (true) {
+			tokenizer.skipWhitespace();
+			String key = parseString(tokenizer);
+			tokenizer.skipWhitespace();
+			tokenizer.consume(':');
+			Object value = parseValue(tokenizer);
+			obj.put(key, value);
+
+			tokenizer.skipWhitespace();
+			char ch = tokenizer.peek();
+			if (ch == '}') {
+				tokenizer.consume('}');
+				break;
+			} else if (ch == ',') {
+				tokenizer.consume(',');
+			} else {
+				throw createParseException("Expected ',' or '}' in object");
+			}
+		}
+
+		return obj;
+	}
+
+	private List<Object> parseArray(JsonTokenizer tokenizer) {
+		List<Object> array = new ArrayList<>();
+		tokenizer.consume('[');
+		tokenizer.skipWhitespace();
+
+		if (tokenizer.peek() == ']') {
+			tokenizer.consume(']');
+			return array;
+		}
+
+		while (true) {
+			Object value = parseValue(tokenizer);
+			array.add(value);
+
+			tokenizer.skipWhitespace();
+			char ch = tokenizer.peek();
+			if (ch == ']') {
+				tokenizer.consume(']');
+				break;
+			} else if (ch == ',') {
+				tokenizer.consume(',');
+			} else {
+				throw createParseException("Expected ',' or ']' in array");
+			}
+		}
+
+		return array;
+	}
+
+	private String parseString(JsonTokenizer tokenizer) {
+		StringBuilder sb = new StringBuilder();
+		tokenizer.consume('"');
+
+		while (tokenizer.hasNext()) {
+			char ch = tokenizer.next();
+			if (ch == '"') {
+				return sb.toString();
+			} else if (ch == '\\') {
+				if (!tokenizer.hasNext()) {
+					throw createParseException("Unterminated string escape");
+				}
+				char escaped = tokenizer.next();
+				switch (escaped) {
+					case '"' -> sb.append('"');
+					case '\\' -> sb.append('\\');
+					case '/' -> sb.append('/');
+					case 'b' -> sb.append('\b');
+					case 'f' -> sb.append('\f');
+					case 'n' -> sb.append('\n');
+					case 'r' -> sb.append('\r');
+					case 't' -> sb.append('\t');
+					default -> throw createParseException("Invalid escape character: \\" + escaped);
+				}
+			} else {
+				sb.append(ch);
+			}
+		}
+
+		throw createParseException("Unterminated string");
+	}
+
+	private Boolean parseBoolean(JsonTokenizer tokenizer) {
+		if (tokenizer.peek() == 't') {
+			tokenizer.consume("true");
+			return true;
+		} else {
+			tokenizer.consume("false");
+			return false;
+		}
+	}
+
+	private Object parseNull(JsonTokenizer tokenizer) {
+		tokenizer.consume("null");
+		return null;
+	}
+
+	private Number parseNumber(JsonTokenizer tokenizer) {
+		StringBuilder sb = new StringBuilder();
+
+		if (tokenizer.peek() == '-') {
+			sb.append(tokenizer.next());
+		}
+
+		while (tokenizer.hasNext() && Character.isDigit(tokenizer.peek())) {
+			sb.append(tokenizer.next());
+		}
+
+		if (tokenizer.hasNext() && tokenizer.peek() == '.') {
+			sb.append(tokenizer.next());
+			while (tokenizer.hasNext() && Character.isDigit(tokenizer.peek())) {
+				sb.append(tokenizer.next());
+			}
+			return Double.parseDouble(sb.toString());
+		}
+
+		return Integer.parseInt(sb.toString());
+	}
+
+	/**
+	 * 파싱된 JSON을 DataRow 리스트로 변환
+	 */
+	@SuppressWarnings("unchecked")
+	private List<DataRow> convertToDataRows(Object parsed) {
+		if (parsed instanceof List) {
+			List<Object> list = (List<Object>) parsed;
+			List<DataRow> result = new ArrayList<>();
+
+			for (Object item : list) {
+				if (item instanceof Map) {
+					DataRow row = convertMapToDataRow((Map<String, Object>) item);
+					result.add(row);
+				}
+			}
+
+			return result;
+		}
+
+		throw createParseException("JSON must be an array of objects");
+	}
+
+	/**
+	 * Map을 DataRow로 변환 (중첩 객체 평면화 포함)
+	 */
+	@SuppressWarnings("unchecked")
+	private DataRow convertMapToDataRow(Map<String, Object> map) {
+		DataRow row = new DataRow();
+		flattenMap(map, "", row);
+		return row;
+	}
+
+	/**
+	 * 중첩된 Map을 평면화하여 DataRow에 저장
+	 */
+	@SuppressWarnings("unchecked")
+	private void flattenMap(Map<String, Object> map, String prefix, DataRow row) {
+		for (Map.Entry<String, Object> entry : map.entrySet()) {
+			String key = prefix.isEmpty() ? entry.getKey() : prefix + "." + entry.getKey();
+			Object value = entry.getValue();
+
+			if (value instanceof Map) {
+				// 중첩 객체 재귀 처리
+				flattenMap((Map<String, Object>) value, key, row);
+			} else if (value instanceof List) {
+				// 배열을 문자열로 변환
+				List<Object> list = (List<Object>) value;
+				String arrayStr = list.stream()
+					.map(Object::toString)
+					.reduce((a, b) -> a + ", " + b)
+					.map(s -> "[" + s + "]")
+					.orElse("[]");
+				row.set(key, arrayStr);
+			} else {
+				row.set(key, value);
+			}
+		}
+	}
+
+	/**
+	 * 간단한 JSON 토크나이저
+	 */
+	private static class JsonTokenizer {
+		private final String json;
+		private int position = 0;
+
+		public JsonTokenizer(String json) {
+			this.json = json;
+		}
+
+		public boolean hasNext() {
+			return position < json.length();
+		}
+
+		public char next() {
+			if (!hasNext()) {
+				throw new ParseException("Unexpected end of JSON");
+			}
+			return json.charAt(position++);
+		}
+
+		public char peek() {
+			if (!hasNext()) {
+				throw new ParseException("Unexpected end of JSON");
+			}
+			return json.charAt(position);
+		}
+
+		public void consume(char expected) {
+			if (!hasNext() || next() != expected) {
+				throw new ParseException("Expected '" + expected + "' at position " + position);
+			}
+		}
+
+		public void consume(String expected) {
+			for (char ch : expected.toCharArray()) {
+				consume(ch);
+			}
+		}
+
+		public void skipWhitespace() {
+			while (hasNext() && Character.isWhitespace(peek())) {
+				next();
+			}
+		}
 	}
 }

--- a/src/main/java/com/datamorph/parser/JsonParser.java
+++ b/src/main/java/com/datamorph/parser/JsonParser.java
@@ -1,0 +1,18 @@
+package com.datamorph.parser;
+
+import com.datamorph.core.DataRow;
+
+import java.io.InputStream;
+import java.util.List;
+
+public class JsonParser implements Parser{
+	@Override
+	public List<DataRow> parse (String content) {
+		return List.of();
+	}
+
+	@Override
+	public List<DataRow> parse (InputStream input) {
+		return List.of();
+	}
+}

--- a/src/main/java/com/datamorph/parser/Parser.java
+++ b/src/main/java/com/datamorph/parser/Parser.java
@@ -1,0 +1,11 @@
+package com.datamorph.parser;
+
+import com.datamorph.core.DataRow;
+
+import java.io.InputStream;
+import java.util.List;
+
+public interface Parser {
+	List<DataRow> parse(String content);
+	List<DataRow> parse(InputStream input);
+}

--- a/src/test/java/com/datamorph/core/DataMorphTest.java
+++ b/src/test/java/com/datamorph/core/DataMorphTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Files;
 

--- a/src/test/java/com/datamorph/fixtures/CsvFixtures.java
+++ b/src/test/java/com/datamorph/fixtures/CsvFixtures.java
@@ -1,0 +1,31 @@
+package com.datamorph.fixtures;
+
+public class CsvFixtures {
+	public static String basicCsv () {
+		return "name,age,city\nJohn,30,Seoul";
+	}
+
+	public static String multiRowCsv () {
+		return """
+				name,age,city
+				John,30,Seoul
+				Jane,25,Busan
+				""".trim();
+	}
+
+	public static String csvWithEmptyFields () {
+		return "name,age,city\nJohn,,Seoul";
+	}
+
+	public static String emptyCsv () {
+		return "name,age,city";
+	}
+
+	public static String basicCsvWithTwoRows () {
+		return "name,age,city\nJohn,30,Seoul\nJane,25,Busan";
+	}
+
+	public static String complexQuotedCsv () {
+		return "name,description,notes\n\"John \"\"JD\"\" Doe\",\"Software Engineer\nWorks at \"\"Big Tech\"\"\",\"Uses Java, Python, and \"\"other\"\" languages\"";
+	}
+}

--- a/src/test/java/com/datamorph/parser/CsvParserTest.java
+++ b/src/test/java/com/datamorph/parser/CsvParserTest.java
@@ -1,0 +1,364 @@
+package com.datamorph.parser;
+
+import com.datamorph.core.DataRow;
+import com.datamorph.error.ParseException;
+import com.datamorph.fixtures.CsvFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+
+class CsvParserTest extends ParserContractTest {
+
+	@Override
+	protected Parser createParser () {
+		return new CsvParser();
+	}
+
+	@Override
+	protected String createBasicData () {
+		return CsvFixtures.basicCsv();
+	}
+
+	@Override
+	protected String createMultiRowData () {
+		return CsvFixtures.multiRowCsv();
+	}
+
+	@Override
+	protected String createDataWithEmptyFields () {
+		return CsvFixtures.csvWithEmptyFields();
+	}
+
+	@Override
+	protected String createEmptyData () {
+		return CsvFixtures.emptyCsv();
+	}
+
+	@Nested
+	@DisplayName("CSV 특화: 구분자 처리")
+	class DelimiterHandling {
+		@ParameterizedTest
+		@MethodSource("delimiterTestCases")
+		@DisplayName("다양한 구분자를 처리할 수 있다")
+		void handleDifferentDelimiters (String csv, char delimiter, String expectedName) {
+			// given
+			CsvParser parser = ((CsvParser) createParser()).withDelimiter(delimiter);
+
+			// when
+			List<DataRow> result = parser.parse(csv);
+
+			// then
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getString("name")).isEqualTo(expectedName);
+		}
+
+		static Stream<Arguments> delimiterTestCases () {
+			String expectedName = "John";
+			return Stream.of(
+					Arguments.arguments("name|age|city\nJohn|30|Seoul", '|', expectedName),
+					Arguments.arguments("name\tage\tcity\nJohn\t30\tSeoul", '\t', expectedName),
+					Arguments.arguments("name;age;city\nJohn;30;Seoul", ';', expectedName)
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("기본 CSV 파싱")
+	class BasicParsing {
+		final CsvParser parser = (CsvParser) createParser();
+
+		@Test
+		@DisplayName("헤더와 데이터가 있는 기본 CSV를 파싱한다")
+		void parseBasicCsv () {
+			// when
+			List<DataRow> result = parser.parse(CsvFixtures.basicCsvWithTwoRows());
+
+			// then
+			assertThat(result).hasSize(2);
+
+			DataRow firstRow = result.get(0);
+			assertThat(firstRow.getString("name")).isEqualTo("John");
+			assertThat(firstRow.getInt("age")).isEqualTo(30);
+			assertThat(firstRow.getString("city")).isEqualTo("Seoul");
+
+			DataRow secondRow = result.get(1);
+			assertThat(secondRow.getString("name")).isEqualTo("Jane");
+			assertThat(secondRow.getInt("age")).isEqualTo(25);
+			assertThat(secondRow.getString("city")).isEqualTo("Busan");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = {"name,age,city", "name", "a,b,c,d,e,f"})
+		@DisplayName("헤더만 있는 CSV를 파싱하면 빈 리스트를 반환한다")
+		void parseHeaderOnlyCsv (String csv) {
+			// when & then
+			assertThat(parser.parse(csv)).isEmpty();
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = {"", "   ", "\n", "\r\n"})
+		@DisplayName("빈 문자열이나 공백만 있으면 예외를 던진다")
+		void parseEmptyOrBlankString (String csv) {
+			// when & then
+			assertThatThrownBy(() -> parser.parse(csv))
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessage("CSV content cannot be null");
+		}
+	}
+
+	@Nested
+	@DisplayName("빈 필드 처리")
+	class EmptyFieldHandling {
+		final CsvParser parser = (CsvParser) createParser();
+
+		@ParameterizedTest
+		@MethodSource("emptyFieldTestCases")
+		@DisplayName("다양한 빈 필드 패턴을 올바르게 처리한다")
+		void handleEmptyFields (String csv, int expectedRows, String description) {
+			// when & then
+			List<DataRow> result = parser.parse(csv);
+			assertThat(result).as(description).hasSize(expectedRows);
+		}
+
+		@ParameterizedTest
+		@MethodSource("emptyFieldNullCases")
+		@DisplayName("빈 필드를 null로 처리한다")
+		void emptyFieldsAsNull (String csv, String field1, String expected1, String field2, String expected2) {
+			// when & then
+			List<DataRow> result = parser.parse(csv);
+
+			assertThat(result).hasSize(1);
+			DataRow row = result.get(0);
+
+			if ("null".equals(expected1)) {
+				assertThat(row.getString(field1)).isNull();
+			} else {
+				assertThat(row.getString(field1)).isEqualTo(expected1);
+			}
+
+			if ("null".equals(expected2)) {
+				assertThat(row.getString(field2)).isNull();
+			} else {
+				assertThat(row.getString(field2)).isEqualTo(expected2);
+			}
+		}
+
+		static Stream<Arguments> emptyFieldTestCases () {
+			return Stream.of(
+					Arguments.arguments("a,b,c\n1,,3", 1, "중간 필드가 비어있는 경우"),
+					Arguments.arguments("a,b,c\n,2,3", 1, "첫 번째 필드가 비어있는 경우"),
+					Arguments.arguments("a,b,c\n1,2,", 1, "마지막 필드가 비어있는 경우"),
+					Arguments.arguments("a,b,c\n,,", 1, "모든 필드가 비어있는 경우"),
+					Arguments.arguments("a,b,c,d\n1,,,4", 1, "연속된 빈 필드가 있는 경우")
+			);
+		}
+
+		static Stream<Arguments> emptyFieldNullCases () {
+			return Stream.of(
+					Arguments.arguments("name,age\nJohn,", "name", "John", "age", "null"),
+					Arguments.arguments("name,age\n,25", "name", "null", "age", "25"),
+					Arguments.arguments("a,b,c\n,,x", "a", "null", "c", "x")
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("따옴표 처리")
+	class QuoteHandling {
+		final CsvParser parser = (CsvParser) createParser();
+
+		@ParameterizedTest
+		@MethodSource("quotedFieldTestCases")
+		@DisplayName("다양한 따옴표 패턴을 올바르게 처리한다")
+		void parseQuotedFields (String csv, String expected, String description) {
+			// when & then
+			List<DataRow> result = parser.parse(csv);
+
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getString("value")).as(description).isEqualTo(expected);
+		}
+
+		@Test
+		@DisplayName("복잡한 따옴표 시나리오를 처리한다")
+		void complexQuotedScenario () {
+			// given
+			String csv = CsvFixtures.complexQuotedCsv();
+
+			// when
+			List<DataRow> result = parser.parse(csv);
+
+			// then
+			assertThat(result).hasSize(1);
+			DataRow row = result.get(0);
+			assertThat(row.getString("name")).isEqualTo("John \"JD\" Doe");
+			assertThat(row.getString("description")).isEqualTo("Software Engineer\nWorks at \"Big Tech\"");
+			assertThat(row.getString("notes")).isEqualTo("Uses Java, Python, and \"other\" languages");
+		}
+
+		static Stream<Arguments> quotedFieldTestCases () {
+			return Stream.of(
+					Arguments.arguments("value\n\"simple\"", "simple", "기본 따옴표"),
+					Arguments.arguments("value\n\"with,comma\"", "with,comma", "따옴표 안의 콤마"),
+					Arguments.arguments("value\n\"with\nnewline\"", "with\nnewline", "따옴표 안의 줄바꿈"),
+					Arguments.arguments("value\n\"with \"\"quotes\"\"\"", "with \"quotes\"", "이스케이프된 따옴표"),
+					Arguments.arguments("value\n\" spaces \"", " spaces ", "따옴표 안의 공백 유지"),
+					Arguments.arguments("value\n\"\"", "", "빈 따옴표"),
+					Arguments.arguments("value\n\"a\"\"b\"\"c\"", "a\"b\"c", "여러 개의 이스케이프된 따옴표")
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("공백 처리")
+	class WhitespaceHandling {
+		final CsvParser parser = (CsvParser) createParser();
+
+
+		@ParameterizedTest
+		@MethodSource("whitespaceTrimCases")
+		@DisplayName("필드 앞뒤 공백을 제거한다")
+		void trimFieldWhitespace (String input, String expected) {
+			// given
+			String csv = "name\n" + input;
+
+			// when
+			List<DataRow> result = parser.parse(csv);
+
+			// then
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getString("name")).isEqualTo(expected);
+		}
+
+		@ParameterizedTest
+		@MethodSource("whitespaceInQuotesTestCases")
+		@DisplayName("따옴표 안의 공백은 유지한다")
+		void preserveWhitespaceInQuotes (String fieldValue, String expected) {
+			// given
+			String csv = "text\n" + fieldValue;
+
+			// when
+			List<DataRow> result = parser.parse(csv);
+
+			// then
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getString("text")).isEqualTo(expected);
+		}
+
+		public static Stream<Arguments> whitespaceInQuotesTestCases () {
+			return Stream.of(
+					Arguments.arguments("\" spaces \"", " spaces "),
+					Arguments.arguments("\"  leading\"", "  leading"),
+					Arguments.arguments("\"trailing  \"", "trailing  "),
+					Arguments.arguments("\"\t\ttabs\t\t\"", "\t\ttabs\t\t"),
+					Arguments.arguments("\" \"", " ")
+			);
+		}
+
+		static Stream<Arguments> whitespaceTrimCases () {
+			return Stream.of(
+					Arguments.arguments(" John ", "John"),
+					Arguments.arguments("  Jane  ", "Jane"),
+					Arguments.arguments("\tBob\t", "Bob"),
+					Arguments.arguments(" \t Mixed \t ", "Mixed")
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("데이터 타입 변환")
+	class DataTypeConversion {
+		final CsvParser parser = (CsvParser) createParser();
+
+		@ParameterizedTest
+		@CsvSource({
+				"123, 123",
+				"'123', 123",
+				"' 123 ', 123",
+				"'+123', 123",
+				"'-123', -123"
+		})
+		@DisplayName("정수 값을 올바르게 파싱한다")
+		void parseIntegerValues (String input, int expected) {
+			// given
+			String csv = "number\n" + input;
+
+			// when
+			List<DataRow> result = parser.parse(csv);
+
+			// then
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getInt("number")).isEqualTo(expected);
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = {"true", "TRUE", "True", "1", "yes", "YES", "y", "Y"})
+		@DisplayName("다양한 true 값을 올바르게 파싱한다")
+		void parseTrueValues (String input) {
+			// given
+			String csv = "flag\n" + input;
+
+			// when
+			List<DataRow> result = parser.parse(csv);
+
+			// then
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getBoolean("flag")).isTrue();
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = {"false", "FALSE", "False", "0", "no", "NO", "n", "N"})
+		@DisplayName("다양한 false 값을 올바르게 파싱한다")
+		void parseFalseValues (String input) {
+			// given
+			String csv = "flag\n" + input;
+
+			// when
+			List<DataRow> result = parser.parse(csv);
+
+			// then
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getBoolean("flag")).isFalse();
+		}
+	}
+
+	@Nested
+	@DisplayName("에러 처리")
+	class ErrorHandling {
+		final CsvParser parser = (CsvParser) createParser();
+
+		@Test
+		@DisplayName("null 입력 시 IllegalArgumentException을 던진다")
+		void throwExceptionOnNull () {
+			// given
+			String csv = null;
+
+			// when & then
+			assertThatThrownBy(() -> parser.parse(csv))
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessage("CSV content cannot be null");
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = {
+				"a,b,c\n1,2",
+				"a,b,c\n1,2,3,4"
+		})
+		@DisplayName("컬럼 수가 맞지 않으면 ParseException을 던진다")
+		void throwExceptionOnColumnMismatch (String csv) {
+			// when & then
+			assertThatThrownBy(() -> parser.parse(csv))
+					.isInstanceOf(ParseException.class)
+					.hasMessageContaining("column");
+		}
+	}
+}

--- a/src/test/java/com/datamorph/parser/JsonParserTest.java
+++ b/src/test/java/com/datamorph/parser/JsonParserTest.java
@@ -1,0 +1,170 @@
+package com.datamorph.parser;
+
+import com.datamorph.error.ParseException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * JsonParser의 테스트 클래스
+ * Parser 인터페이스의 공통 계약과 JSON 특화 기능을 모두 테스트합니다.
+ */
+class JsonParserTest extends ParserContractTest {
+
+	@Override
+	protected Parser createParser () {
+		return new JsonParser();
+	}
+
+	@Override
+	protected String createBasicData () {
+		return """
+				[
+				    {"name": "John", "age": 30, "city": "Seoul"}
+				]
+				""".trim();
+	}
+
+	@Override
+	protected String createMultiRowData () {
+		return """
+				[
+				    {"name": "John", "age": 30, "city": "Seoul"},
+				    {"name": "Jane", "age": 25, "city": "Busan"}
+				]
+				""".trim();
+	}
+
+	@Override
+	protected String createDataWithEmptyFields () {
+		return """
+				[
+				    {"name": "John", "age": null, "city": "Seoul"}
+				]
+				""".trim();
+	}
+
+	@Override
+	protected String createEmptyData () {
+		return "[]";
+	}
+
+	// ===== JSON 특화 테스트 =====
+
+	@Nested
+	@DisplayName("JSON 특화: 중첩 객체 처리")
+	class NestedObjectHandling {
+
+		@Test
+		@DisplayName("중첩된 객체를 평면화하여 처리한다")
+		void handleNestedObjects () {
+			// given
+			String json = """
+					[
+					    {
+					        "name": "John",
+					        "address": {
+					            "city": "Seoul",
+					            "country": "Korea"
+					        }
+					    }
+					]
+					""".trim();
+
+			// when
+			var result = createParser().parse(json);
+
+			// then
+			assertThat(result).hasSize(1);
+			var row = result.get(0);
+			assertThat(row.getString("name")).isEqualTo("John");
+			assertThat(row.getString("address.city")).isEqualTo("Seoul");
+			assertThat(row.getString("address.country")).isEqualTo("Korea");
+		}
+	}
+
+	@Nested
+	@DisplayName("JSON 특화: 배열 처리")
+	class ArrayHandling {
+
+		@Test
+		@DisplayName("배열 필드를 문자열로 변환한다")
+		void handleArrayFields () {
+			// given
+			String json = """
+					[
+					    {
+					        "name": "John",
+					        "skills": ["Java", "Python", "JavaScript"]
+					    }
+					]
+					""".trim();
+
+			// when
+			var result = createParser().parse(json);
+
+			// then
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getString("skills"))
+					.isEqualTo("[Java, Python, JavaScript]");
+		}
+	}
+
+	@Nested
+	@DisplayName("JSON 특화: 다양한 데이터 타입")
+	class DataTypeHandling {
+
+		@Test
+		@DisplayName("JSON의 다양한 데이터 타입을 올바르게 처리한다")
+		void handleVariousDataTypes () {
+			// given
+			String json = """
+					[
+					    {
+					        "string": "text",
+					        "integer": 42,
+					        "float": 3.14,
+					        "boolean": true,
+					        "null": null
+					    }
+					]
+					""".trim();
+
+			// when
+			var result = createParser().parse(json);
+
+			// then
+			assertThat(result).hasSize(1);
+			var row = result.get(0);
+			assertThat(row.getString("string")).isEqualTo("text");
+			assertThat(row.getInt("integer")).isEqualTo(42);
+			assertThat(row.getString("float")).isEqualTo("3.14");
+			assertThat(row.getBoolean("boolean")).isTrue();
+			assertThat(row.getString("null")).isNull();
+		}
+	}
+
+	@Nested
+	@DisplayName("JSON 특화: 형식 오류 처리")
+	class MalformedJsonHandling {
+
+		@ParameterizedTest
+		@ValueSource(strings = {
+				"{",                    // 불완전한 JSON
+				"[{\"name\": }]",      // 값 누락
+				"[{name: \"John\"}]",  // 따옴표 없는 키
+				"{'name': 'John'}",    // 작은따옴표 사용
+		})
+		@DisplayName("잘못된 JSON 형식에 대해 ParseException을 던진다")
+		void throwExceptionForMalformedJson (String json) {
+			// when & then
+			assertThatThrownBy(() -> createParser().parse(json))
+					.isInstanceOf(ParseException.class)
+					.hasMessageContaining("Invalid JSON");
+		}
+	}
+}

--- a/src/test/java/com/datamorph/parser/ParserContractTest.java
+++ b/src/test/java/com/datamorph/parser/ParserContractTest.java
@@ -1,0 +1,246 @@
+package com.datamorph.parser;
+
+import com.datamorph.core.DataRow;
+import com.datamorph.error.ParseException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Parser 인터페이스의 공통 계약을 테스트하는 추상 클래스
+ * 모든 Parser 구현체는 이 테스트를 통과해야 합니다.
+ */
+public abstract class ParserContractTest {
+    
+    /**
+     * 테스트할 Parser 인스턴스를 생성합니다.
+     */
+    protected abstract Parser createParser();
+    
+    /**
+     * 기본 데이터를 해당 포맷으로 생성합니다.
+     * 데이터: name=John, age=30, city=Seoul
+     */
+    protected abstract String createBasicData();
+    
+    /**
+     * 여러 행의 데이터를 해당 포맷으로 생성합니다.
+     * 데이터: 
+     * - name=John, age=30, city=Seoul
+     * - name=Jane, age=25, city=Busan
+     */
+    protected abstract String createMultiRowData();
+    
+    /**
+     * 빈 필드가 포함된 데이터를 생성합니다.
+     * 데이터: name=John, age=null, city=Seoul
+     */
+    protected abstract String createDataWithEmptyFields();
+    
+    /**
+     * 빈 데이터를 생성합니다. (데이터 없음, 헤더만 있거나 완전히 비어있음)
+     */
+    protected abstract String createEmptyData();
+    
+    @Nested
+    @DisplayName("공통 계약: 기본 파싱")
+    class BasicParsingContract {
+        
+        @Test
+        @DisplayName("기본 데이터를 파싱할 수 있다")
+        void shouldParseBasicData() {
+            // given
+            Parser parser = createParser();
+            String data = createBasicData();
+            
+            // when
+            List<DataRow> result = parser.parse(data);
+            
+            // then
+            assertThat(result).hasSize(1);
+            DataRow row = result.get(0);
+            assertThat(row.getString("name")).isEqualTo("John");
+            assertThat(row.getInt("age")).isEqualTo(30);
+            assertThat(row.getString("city")).isEqualTo("Seoul");
+        }
+        
+        @Test
+        @DisplayName("여러 행의 데이터를 파싱할 수 있다")
+        void shouldParseMultipleRows() {
+            // given
+            Parser parser = createParser();
+            String data = createMultiRowData();
+            
+            // when
+            List<DataRow> result = parser.parse(data);
+            
+            // then
+            assertThat(result).hasSize(2);
+            
+            DataRow firstRow = result.get(0);
+            assertThat(firstRow.getString("name")).isEqualTo("John");
+            assertThat(firstRow.getInt("age")).isEqualTo(30);
+            assertThat(firstRow.getString("city")).isEqualTo("Seoul");
+            
+            DataRow secondRow = result.get(1);
+            assertThat(secondRow.getString("name")).isEqualTo("Jane");
+            assertThat(secondRow.getInt("age")).isEqualTo(25);
+            assertThat(secondRow.getString("city")).isEqualTo("Busan");
+        }
+        
+        @Test
+        @DisplayName("빈 데이터를 파싱하면 빈 리스트를 반환한다")
+        void shouldReturnEmptyListForEmptyData() {
+            // given
+            Parser parser = createParser();
+            String data = createEmptyData();
+            
+            // when
+            List<DataRow> result = parser.parse(data);
+            
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+    
+    @Nested
+    @DisplayName("공통 계약: null 및 빈 필드 처리")
+    class NullAndEmptyHandlingContract {
+        
+        @Test
+        @DisplayName("null 입력 시 IllegalArgumentException을 던진다")
+        void shouldThrowExceptionForNullInput() {
+            // given
+            Parser parser = createParser();
+            
+            // when & then
+            assertThatThrownBy(() -> parser.parse((String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("null");
+        }
+        
+        @Test
+        @DisplayName("빈 필드를 null로 처리한다")
+        void shouldHandleEmptyFieldsAsNull() {
+            // given
+            Parser parser = createParser();
+            String data = createDataWithEmptyFields();
+            
+            // when
+            List<DataRow> result = parser.parse(data);
+            
+            // then
+            assertThat(result).hasSize(1);
+            DataRow row = result.get(0);
+            assertThat(row.getString("name")).isEqualTo("John");
+            assertThat(row.getString("age")).isNull();
+            assertThat(row.getString("city")).isEqualTo("Seoul");
+        }
+    }
+    
+    @Nested
+    @DisplayName("공통 계약: 입력 스트림 파싱")
+    class InputStreamParsingContract {
+        
+        @Test
+        @DisplayName("InputStream으로부터 데이터를 파싱할 수 있다")
+        void shouldParseFromInputStream() throws IOException {
+            // given
+            Parser parser = createParser();
+            String data = createBasicData();
+            InputStream input = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
+            
+            // when
+            List<DataRow> result = parser.parse(input);
+            
+            // then
+            assertThat(result).hasSize(1);
+            DataRow row = result.get(0);
+            assertThat(row.getString("name")).isEqualTo("John");
+            assertThat(row.getInt("age")).isEqualTo(30);
+            assertThat(row.getString("city")).isEqualTo("Seoul");
+        }
+        
+        @Test
+        @DisplayName("null InputStream 시 IllegalArgumentException을 던진다")
+        void shouldThrowExceptionForNullInputStream() {
+            // given
+            Parser parser = createParser();
+            
+            // when & then
+            assertThatThrownBy(() -> parser.parse((InputStream) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("null");
+        }
+        
+        @Test
+        @DisplayName("빈 InputStream을 파싱하면 빈 리스트를 반환한다")
+        void shouldReturnEmptyListForEmptyInputStream() throws IOException {
+            // given
+            Parser parser = createParser();
+            InputStream input = new ByteArrayInputStream(new byte[0]);
+            
+            // when
+            List<DataRow> result = parser.parse(input);
+            
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+    
+    @Nested
+    @DisplayName("공통 계약: 데이터 타입 변환")
+    class DataTypeConversionContract {
+        
+        @Test
+        @DisplayName("기본 데이터 타입을 올바르게 처리한다")
+        void shouldHandleBasicDataTypes() {
+            // given
+            Parser parser = createParser();
+            String data = createBasicData();
+            
+            // when
+            List<DataRow> result = parser.parse(data);
+            
+            // then
+            DataRow row = result.get(0);
+            
+            // String 타입
+            assertThat(row.getString("name")).isEqualTo("John");
+            assertThat(row.getString("city")).isEqualTo("Seoul");
+            
+            // Integer 타입
+            assertThat(row.getInt("age")).isEqualTo(30);
+            
+            // null 처리
+            assertThat(row.getString("nonexistent")).isNull();
+        }
+    }
+    
+    @Nested
+    @DisplayName("공통 계약: 에러 처리")
+    class ErrorHandlingContract {
+        
+        @Test
+        @DisplayName("잘못된 형식의 데이터 파싱 시 ParseException을 던진다")
+        void shouldThrowParseExceptionForInvalidFormat() {
+            // given
+            Parser parser = createParser();
+            String invalidData = "This is not a valid format for any parser!@#$%^&*()";
+            
+            // when & then
+            assertThatThrownBy(() -> parser.parse(invalidData))
+                .isInstanceOf(ParseException.class);
+        }
+    }
+}

--- a/test.csv
+++ b/test.csv
@@ -1,0 +1,2 @@
+text
+" spaces "


### PR DESCRIPTION
### 🎯 목표
```java
public interface Parser {
    List<DataRow> parse(String content);
    List<DataRow> parse(InputStream input) throws IOException;
}
```
- 단일 책임 : 문자열 / 스트림을 `DataRow` 리스트로 변환
- 포맷 독립성 : CSV, JSON, XML 등 다양한 포맷 지원
- 확장성 : 새로운 포맷을 쉽게 추가 가능

---

### 💻 Parser 인터페이스 설계
#### 핵심 메서드와 기능
**기본 파싱 메서드**
```java
List<DataRow> parse(String content)
```
- 기능 : 문자열을 파싱하여 `DataRow` 리스트로 변환
- 예시 : `parser.parse("name,age\nJohn,30")`
- 테스트 케이스
  - 정상적인 CSV 파싱
  - 빈 문자열 처리
  - null 입력 시 예외
  - 헤더만 있는 경우
  - 데이터만 있는 경우

```java
List<DataRow> parse(InputStream input)
```
- 기능 : 스트림에서 데이터를 읽어 파싱
- 예시 : `parser.parse(new FileInputStream("data.csv")`
- 테스트 케이스
  - 파일 스트림 파싱
  - 네트워크 스트림 파싱
  - 인코딩 처리
  - BOM 처리
  - 대용량 파일 처리

**스트리밍 파싱 메서드**
```java
Stream<DataRow> stream(InputStream input)
```
- 기능 : 메모리 효율적인 스트리밍 파싱
- 예시 : `parser.stream(input).filter(...).forEach()`
- 테스트 케이스
  - 한 번에 한 행씩 처리
  - 메모리 사용량 제한
  - 백프레셔 처리
  - 중간에 중단 가능

**설정 메서드**
```java
Parser withDelimiter(char delimiter)
```
- 기능 : 구분자 설정
- 예시 : `parser.withDelimiter('\t')`
- 테스트 케이스
  - 콤마 구분자
  - 탭 구분자
  - 파이프 구분자
  - 사용자 정의 구분자

```java
Parser withQuoteChar(char quote)
```
- 기능 : 인용 문자 설정
- 예시 : `parser.withQuoteChar('\'')`
- 테스트 케이스
  - 큰따옴표
  - 작은따옴표
  - 인용 문자 없음

```java
Parser withHeaders(boolean hasHeaders)
```
- 기능 : 헤더 존재 여부 설정
- 예시 : `parser.withHeaders(false)`
- 테스트 케이스
  - 첫 번째 행을 헤더로 사용
  - 헤더 없이 기본 컬럼명 생성
  - 사용자 정의 헤더 제공

**에러 처리 메서드**
```java
Parser skipErrors(boolean skip)
```
- 기능 : 파싱 에러 스킵 여부 설정
- 예시 : `parser.skipErrors(true)`
- 테스트 케이스
  - 에러 행 스킵하고 계속 파싱
  - 첫 번째 에러에서 중단
  - 에러 정보 수집

---

### 📌 구현 고려사항
- Fluent API : 모든 설정 메서드는 `Parser`를 반환하여 체이닝 가능
- 설정 변경 시 새로운 `Parser` 인스턴스 반환
- 포맷별 `Parser` 생성
- Strategy Pattern 파싱 전략 분리
  - 인용 문자 처리
  - 구분자 처리
  - 타입 변환